### PR TITLE
authenticate_user while authenticate_admin_user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,8 @@ class ApplicationController < ActionController::Base
 
   #This method is for activeadmin to only allow admin users to acces the admin page from the url
   def authenticate_admin_user!
-    raise SecurityError unless current_user && current_user.admin?
+    authenticate_user!
+    raise SecurityError unless current_user.admin?
   end
   # Show action authorization: rescue when record does not exists
   rescue_from ActiveRecord::RecordNotFound, :with => :record_not_found


### PR DESCRIPTION
Thank you Raymond for letting me participate your code. In my opinion `authenticate_user!` checks if user logged in as like `current_user` does, and also `current_user` returns a user object (while I don't know in Devise code they call `current_user` inside of `authenticate_user!`) Another reason I thought was you can get a different errors and the error from `authenticate_user!` fits more in case user goes to `/admin` page without logging in. 
